### PR TITLE
Minimal CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    # We don't want to build openmpi each time this workflow is
+    # run. Setup caching of OpenMPI after it is built and installed.
+    # See "Caching dependencies to speed up workflows" on the GH
+    # actions docs.
+    - name: Cache OpenMPI
+      id: cache-openmpi
+      uses: actions/cache@v2
+      with:
+        path: openmpi-4.1.2/installed
+        key: openmpi-4.1.2
+
+    - name: Build openmpi
+      if: steps.cache-openmpi.outputs.cache-hit != 'true'
+      run: |
+        wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz
+        tar -xf openmpi-4.1.2.tar.gz
+        cd openmpi-4.1.2/ && mkdir installed
+        ./configure --prefix=$(pwd)/installed
+        make all install
+
+    # Just a way to interact with a github runner through ssh, using
+    # tmate. Useful for debugging in case sthg goes wrong. See
+    # https://github.com/marketplace/actions/debugging-with-tmate
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,7 @@ jobs:
         ./configure --prefix=$(pwd)/installed
         make all install
 
-    # Just a way to interact with a github runner through ssh, using
-    # tmate. Useful for debugging in case sthg goes wrong. See
-    # https://github.com/marketplace/actions/debugging-with-tmate
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
+    - name: Build x3div
+      run: |
+        export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
+        make CMP=gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,3 +34,9 @@ jobs:
       run: |
         export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
         make CMP=gcc
+
+    - name: Run default benchmark
+      run: |
+        export PATH=$(pwd)/openmpi-4.1.2/installed/bin/:$PATH
+        export LD_LIBRARY_PATH=$(pwd)/openmpi-4.1.2/installed/lib:$LD_LIBRARY_PATH
+        mpirun -n 1 xcompact3d


### PR DESCRIPTION
This adds a basic workflow that
- Builds and caches OpenMPI.
- Builds x3div with GCC.
- Runs the default benchmark with a single process.

The workflow is described in `.github/workflows/build.yml`. See [Understanding GitHub actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions) for an intro to writing workflows. Nothing special about this one, but this lays the groundwork for future infrastructure like unit tests. The workflow is triggered each time commits are pushed to a remote branch, running on Ubuntu 20.04.

AFAIK the only dependency for running the default benchamrk is OpenMPI. Installing it from the Ubuntu repos (`apt install libopenmpi-dev` or something similar) would simplify the workflow, but I figured we would prefer having control on the OpenMPI version we test against, as well as its compilation. However, we don't want to build OpenMPI each time, so the installed libraries and headers are cached. This is standard GitHub actions practice, see [Caching dependencies to speed up workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows).

### Limitations, potential improvements or further work
- Maybe it would desirable to have more control on the OpenMPI build: version(s), compiler, compiler options. We would have to make sure the cache key depends on these, so that whenever one variable changes, so does the cache key and the build is triggered. Building MPI is probably here to stay, so maybe worth having a separate action to build it? 
- For now x3div is built with gcc only.