### PR TITLE
Minimal cmake build (GCC + generic FFT)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.12)
+cmake_policy(SET CMP0074 NEW)
+
+project(xcompact3d LANGUAGES Fortran)
+
+find_package(MPI REQUIRED)
+if (MPI_Fortran_COMPILER)
+  message(STATUS "MPI_Fortran_COMPILER found: ${MPI_Fortran_COMPILER}")
+else (MPI_Fortran_COMPILER)
+  message(SEND_ERROR "This application cannot compile without MPI")
+endif(MPI_Fortran_COMPILER)
+
+# Warning if Include are not found => can be fixed with more recent cmake version
+if (MPI_FOUND)
+  message(STATUS "MPI FOUND: ${MPI_FOUND}")
+  include_directories(SYSTEM ${MPI_INCLUDE_PATH})
+  message(STATUS "MPI INCL ALSO FOUND: ${MPI_INCLUDE_PATH}")
+else (MPI_FOUND)
+  message(STATUS "NO MPI include have been found. The executable won't be targeted with MPI include")
+  message(STATUS "Code will compile but performaces can be compromised")
+  message(STATUS "Using a CMake vers > 3.10 should solve the problem")
+  message(STATUS "Alternatively use ccmake to manually set the include if available")
+endif (MPI_FOUND)
+
+
+set(CMAKE_Fortran_FLAGS "-cpp -funroll-loops -floop-optimize -g
+-Warray-bounds -fcray-pointer -fbacktrace -ffree-line-length-none")
+
+# Create a static library for the fft
+add_subdirectory(decomp2d)
+
+# Create the Xcompact3d executable
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,18 +10,6 @@ else (MPI_Fortran_COMPILER)
   message(SEND_ERROR "This application cannot compile without MPI")
 endif(MPI_Fortran_COMPILER)
 
-# Warning if Include are not found => can be fixed with more recent cmake version
-if (MPI_FOUND)
-  message(STATUS "MPI FOUND: ${MPI_FOUND}")
-  include_directories(SYSTEM ${MPI_INCLUDE_PATH})
-  message(STATUS "MPI INCL ALSO FOUND: ${MPI_INCLUDE_PATH}")
-else (MPI_FOUND)
-  message(STATUS "NO MPI include have been found. The executable won't be targeted with MPI include")
-  message(STATUS "Code will compile but performaces can be compromised")
-  message(STATUS "Using a CMake vers > 3.10 should solve the problem")
-  message(STATUS "Alternatively use ccmake to manually set the include if available")
-endif (MPI_FOUND)
-
 # Create a static library for the fft
 add_subdirectory(decomp2d)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,6 @@ else (MPI_FOUND)
   message(STATUS "Alternatively use ccmake to manually set the include if available")
 endif (MPI_FOUND)
 
-
-set(CMAKE_Fortran_FLAGS "-cpp -funroll-loops -floop-optimize -g
--Warray-bounds -fcray-pointer -fbacktrace -ffree-line-length-none")
-
 # Create a static library for the fft
 add_subdirectory(decomp2d)
 

--- a/decomp2d/CMakeLists.txt
+++ b/decomp2d/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB files_decomp decomp_2d.f90 glassman.f90)
+file(GLOB files_fft fft_generic.f90)
+set(SRCFILES ${files_decomp} ${files_fft})
+
+add_library(decomp2d STATIC ${SRCFILES})
+target_link_libraries(decomp2d PRIVATE MPI::MPI_Fortran)
+install(TARGETS decomp2d
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/decomp2d/CMakeLists.txt
+++ b/decomp2d/CMakeLists.txt
@@ -4,6 +4,10 @@ set(SRCFILES ${files_decomp} ${files_fft})
 
 add_library(decomp2d STATIC ${SRCFILES})
 target_link_libraries(decomp2d PRIVATE MPI::MPI_Fortran)
+
+include(cmake/gfortran_flags.cmake)
+target_compile_options(decomp2d PRIVATE ${gfortran_flags})
+
 install(TARGETS decomp2d
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/decomp2d/cmake/gfortran_flags.cmake
+++ b/decomp2d/cmake/gfortran_flags.cmake
@@ -1,0 +1,10 @@
+set(gfortran_flags
+  -cpp
+  -funroll-loops
+  -floop-optimize
+  -g
+  -Warray-bounds
+  -fcray-pointer
+  -fbacktrace
+  -ffree-line-length-none
+  )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(SRCFILES
+  xcompact3d.f90
+  case.f90
+  derive.f90
+  module_param.f90
+  mom.f90
+  navier.f90
+  parameters.f90
+  poisson.f90
+  schemes.f90
+  transeq.f90
+  variables.f90
+  )
+
+add_executable(xcompact3d ${SRCFILES})
+
+target_include_directories(xcompact3d PRIVATE ${PROJECT_BINARY_DIR}/decomp2d)
+target_link_libraries(xcompact3d PRIVATE decomp2d)
+target_link_libraries(xcompact3d PRIVATE MPI::MPI_Fortran)
+
+install(TARGETS xcompact3d
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,9 @@ target_include_directories(xcompact3d PRIVATE ${PROJECT_BINARY_DIR}/decomp2d)
 target_link_libraries(xcompact3d PRIVATE decomp2d)
 target_link_libraries(xcompact3d PRIVATE MPI::MPI_Fortran)
 
+include(cmake/gfortran_flags.cmake)
+target_compile_options(xcompact3d PRIVATE ${gfortran_flags})
+
 install(TARGETS xcompact3d
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/src/cmake/gfortran_flags.cmake
+++ b/src/cmake/gfortran_flags.cmake
@@ -1,0 +1,10 @@
+set(gfortran_flags
+  -cpp
+  -funroll-loops
+  -floop-optimize
+  -g
+  -Warray-bounds
+  -fcray-pointer
+  -fbacktrace
+  -ffree-line-length-none
+  )


### PR DESCRIPTION
Stripped down version of the build currently in place in the hack_doconcurrent branch. It contains only the ingredients necessary to build and install with GCC and the generic FFT module.

I removed the call to `include_directories(SYSTEM ${MPI_INCLUDE_PATH})` (see [a9cecd2](https://github.com/xcompact3d/x3div/commit/a9cecd2a550add7aead3061b4a8a878c61b43bd8)). It seemed redundant with linking with `MPI::MPI_Fortran` in both subdirectories. Moreover, if the issue is irrelevant with CMake > 3.10 as the `message`s suggest, then we're good with the `cmake_minimum_required` being 3.12?

The targets' `COMPILE_OPTIONS` is set instead of defining `CMAKE_Fortran_flags`. If I remember correcly, `CMAKE_*_FLAGS` variables are meant to be defined when calling cmake to add flags on top of the list ([docs](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html)). Using `COMPILE_OPTIONS` allows to define a list of flags instead of a single string. CMake deals with escaping if needed. 