### PR TITLE
Add a test for `derx_11`, parameterized on pencil size

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,15 @@
 find_package(PFUNIT REQUIRED)
 enable_testing()
 
-set(test_src test_dummy.pf)
-add_pfunit_ctest(tests TEST_SOURCES ${test_src})
+set(test_src test_dummy.pf test_deriv.pf)
+set(other_src
+  ../src/module_param.f90
+  )
+add_pfunit_ctest(tests
+  TEST_SOURCES ${test_src}
+  OTHER_SOURCES ${other_src}
+  LINK_LIBRARIES decomp2d # module param uses "mytype" from decomp2d
+  )
+target_include_directories(tests PRIVATE ${PROJECT_BINARY_DIR}/decomp2d)
+target_compile_options(tests PRIVATE -cpp)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ enable_testing()
 set(test_src test_dummy.pf test_deriv.pf)
 set(other_src
   ../src/module_param.f90
+  ../src/derive.f90
   )
 add_pfunit_ctest(tests
   TEST_SOURCES ${test_src}

--- a/tests/test_deriv.pf
+++ b/tests/test_deriv.pf
@@ -2,6 +2,17 @@ module test_deriv
   use funit
   implicit none
 
+  ! Explicit interface required as long as derivative functions
+  ! are not defined in a module.
+  interface
+     subroutine derx_11(tx,ux,rx,sx,ffx,fsx,fwx,nx,ny,nz,npaire)
+       integer :: nx,ny,nz,npaire
+       real, dimension(nx,ny,nz) :: tx,ux,rx
+       real, dimension(ny,nz):: sx
+       real, dimension(nx):: ffx,fsx,fwx
+     end subroutine derx_11
+  end interface
+
   @testParameter
   type, extends(AbstractTestParameter) :: pencilSize
      integer :: nx, ny, nz
@@ -117,7 +128,7 @@ module test_deriv
          & this % pencil_size % nx, &
          & this % pencil_size % ny, &
          & this % pencil_size % nz, &
-         0)
+         npaire = 0)
 
     @assertEqual(dfunc, expected_dfunc, tolerance=1E-2)
 

--- a/tests/test_deriv.pf
+++ b/tests/test_deriv.pf
@@ -14,6 +14,7 @@ module test_deriv
       type(pencilSize) :: pencil_size
     contains
       procedure :: allocate_on_pencil
+      procedure :: setup_coefficient_arrays
    end type testDeriv
 
  contains
@@ -43,6 +44,35 @@ module test_deriv
           & )
    end subroutine allocate_on_pencil
 
+   subroutine setup_coefficient_arrays(this, ff, fs, fw)
+     class(testDeriv), intent(in) :: this
+     real, allocatable, intent(out) :: ff(:), fs(:), fw(:)
+
+     real, allocatable :: fb(:)
+     real, parameter :: alfai = 1. / 3.
+     integer :: i
+
+     ff = [(alfai, i = 1,this % pencil_size % nx)]
+     ff(1) = alfai + alfai
+     ff(this % pencil_size % nx) = 0.
+     fw = [(1., i = 1,this % pencil_size % nx)]
+     fs = [(0., i = 1,this % pencil_size % nx)]
+
+     fb = [(alfai, i = 1, this % pencil_size % nx)]
+     fb(this % pencil_size % nx - 1) = alfai + alfai
+     fb(this % pencil_size % nx) = 0.
+     do i=2,this % pencil_size % nx
+        fs(i) = fb(i-1) / fw(i-1)
+        fw(i) = fw(i) - ff(i-1) * fs(i)
+     enddo
+     do i=1,this % pencil_size % nx
+        fw(i) = 1. / fw(i)
+     enddo
+     fs(1) = 0.
+
+     deallocate(fb)
+   end subroutine setup_coefficient_arrays
+
    function toString(this) result(string)
      class(pencilSize), intent(in) :: this
      character(:), allocatable :: string
@@ -56,12 +86,15 @@ module test_deriv
     use param, only: pi
     class (testDeriv), intent(inout) :: this
     real, allocatable, dimension(:, :, :) :: func, dfunc, expected_dfunc
+    real, allocatable :: ff(:), fs(:), fw(:)
     integer :: i, j, k
     real :: x, dx
 
     call this % allocate_on_pencil(func)
     call this % allocate_on_pencil(dfunc)
     call this % allocate_on_pencil(expected_dfunc)
+
+    call this % setup_coefficient_arrays(ff, fs, fw)
 
     dx = 1. / (this % pencil_size % nx - 1)
     do k=1,this % pencil_size % nz
@@ -73,7 +106,7 @@ module test_deriv
           enddo
        enddo
     enddo
-    
+
     write(*, *) this % pencil_size % toString()
 
     @assertTrue(1 > 0)
@@ -83,4 +116,3 @@ module test_deriv
   end subroutine test_derx_odd_11
 
 end module test_deriv
-

--- a/tests/test_deriv.pf
+++ b/tests/test_deriv.pf
@@ -53,12 +53,26 @@ module test_deriv
 
   @test
   subroutine test_derx_odd_11(this)
+    use param, only: pi
     class (testDeriv), intent(inout) :: this
     real, allocatable, dimension(:, :, :) :: func, dfunc, expected_dfunc
+    integer :: i, j, k
+    real :: x, dx
 
     call this % allocate_on_pencil(func)
     call this % allocate_on_pencil(dfunc)
     call this % allocate_on_pencil(expected_dfunc)
+
+    dx = 1. / (this % pencil_size % nx - 1)
+    do k=1,this % pencil_size % nz
+       do j=1,this % pencil_size % ny
+          do i=1,this % pencil_size % nx
+             x = (i - 1.) * dx * 4. * pi
+             func(i,j,k) = sin(x)  !odd
+             expected_dfunc(i,j,k) = 4. * pi * cos(x)
+          enddo
+       enddo
+    enddo
     
     write(*, *) this % pencil_size % toString()
 

--- a/tests/test_deriv.pf
+++ b/tests/test_deriv.pf
@@ -84,9 +84,12 @@ module test_deriv
   @test
   subroutine test_derx_odd_11(this)
     use param, only: pi
+    use derivX, only: afix, bfix
+
     class (testDeriv), intent(inout) :: this
     real, allocatable, dimension(:, :, :) :: func, dfunc, expected_dfunc
     real, allocatable :: ff(:), fs(:), fw(:)
+    real, allocatable :: s(:, :), di1(:, :, :)
     integer :: i, j, k
     real :: x, dx
 
@@ -107,9 +110,16 @@ module test_deriv
        enddo
     enddo
 
-    write(*, *) this % pencil_size % toString()
+    afix = (7. / 9.) / dx
+    bfix = (1. / 36.) / dx
+    allocate(s(this % pencil_size % ny, this % pencil_size % nz))
+    call derx_11(dfunc, func, di1, s, ff, fs, fw, &
+         & this % pencil_size % nx, &
+         & this % pencil_size % ny, &
+         & this % pencil_size % nz, &
+         0)
 
-    @assertTrue(1 > 0)
+    @assertEqual(dfunc, expected_dfunc, tolerance=1E-2)
 
     deallocate(func, dfunc, expected_dfunc)
 

--- a/tests/test_deriv.pf
+++ b/tests/test_deriv.pf
@@ -12,6 +12,8 @@ module test_deriv
    @testCase(testParameters={getParameters()}, constructor=newTestDeriv)
    type, extends(ParameterizedTestCase) :: testDeriv
       type(pencilSize) :: pencil_size
+    contains
+      procedure :: allocate_on_pencil
    end type testDeriv
 
  contains
@@ -31,6 +33,16 @@ module test_deriv
           & ]
    end function getParameters
 
+   subroutine allocate_on_pencil(this, array)
+     class(testDeriv), intent(in) :: this
+     real, allocatable, intent(inout) :: array(:, :, :)
+     allocate(array( &
+          & this % pencil_size % nx, &
+          & this % pencil_size % ny, &
+          & this % pencil_size % nz) &
+          & )
+   end subroutine allocate_on_pencil
+
    function toString(this) result(string)
      class(pencilSize), intent(in) :: this
      character(:), allocatable :: string
@@ -42,10 +54,17 @@ module test_deriv
   @test
   subroutine test_derx_odd_11(this)
     class (testDeriv), intent(inout) :: this
+    real, allocatable, dimension(:, :, :) :: func, dfunc, expected_dfunc
 
+    call this % allocate_on_pencil(func)
+    call this % allocate_on_pencil(dfunc)
+    call this % allocate_on_pencil(expected_dfunc)
+    
     write(*, *) this % pencil_size % toString()
 
     @assertTrue(1 > 0)
+
+    deallocate(func, dfunc, expected_dfunc)
 
   end subroutine test_derx_odd_11
 

--- a/tests/test_deriv.pf
+++ b/tests/test_deriv.pf
@@ -1,0 +1,53 @@
+module test_deriv
+  use funit
+  implicit none
+
+  @testParameter
+  type, extends(AbstractTestParameter) :: pencilSize
+     integer :: nx, ny, nz
+   contains
+     procedure :: toString
+   end type pencilSize
+
+   @testCase(testParameters={getParameters()}, constructor=newTestDeriv)
+   type, extends(ParameterizedTestCase) :: testDeriv
+      type(pencilSize) :: pencil_size
+   end type testDeriv
+
+ contains
+
+   function newTestDeriv(param)
+     type(testDeriv) :: newTestDeriv
+     type(pencilSize), intent(in) :: param
+     newTestDeriv%pencil_size = param
+   end function newTestDeriv
+
+   function getParameters() result(test_pencil_sizes)
+     type(pencilSize), allocatable :: test_pencil_sizes(:)
+     test_pencil_sizes = [ &
+          & pencilSize(16,16,16), &
+          & pencilSize(32,32,32), &
+          & pencilSize(64,64,64) &
+          & ]
+   end function getParameters
+
+   function toString(this) result(string)
+     class(pencilSize), intent(in) :: this
+     character(:), allocatable :: string
+     character(len=80) :: buffer
+     write(buffer, '("nx = ",i3.3,1x,"ny = ( ",i3.3,1x,"nz = ( ",i3.3)')
+     string = trim(buffer)
+   end function toString
+
+  @test
+  subroutine test_derx_odd_11(this)
+    class (testDeriv), intent(inout) :: this
+
+    write(*, *) this % pencil_size % toString()
+
+    @assertTrue(1 > 0)
+
+  end subroutine test_derx_odd_11
+
+end module test_deriv
+


### PR DESCRIPTION
This uses pFUnit to test `derx_11`. The test is automatically run for a collection of pencil sizes, returned by the `getParameters` function.

Running parametrized tests with pFUnit is mostly undocumented. My changes are adapted from the (allegedly outdated) examples available at [pFUnit/Examples/ParameterizedTest](https://github.com/Goddard-Fortran-Ecosystem/pFUnit/tree/main/Examples/ParameterizedTest). There is an ongoing discussion with PFUnit's maintainer on what is the up to date way of defining parametrized test, see [pFUnit#364](https://github.com/Goddard-Fortran-Ecosystem/pFUnit/issues/364#issuecomment-1160887837), although it seems that the current implementation isn't to far from it. Most importantly for now: it compiles and runs.

The main idea is to define two derived types: one for the test parameter (extending `AbstractTestParameter`) and one for the test itelf (extending `ParameterizedTest`) that has a parameter attribute. pFUnit builds the test suite by instanciating the derived test type for each value of the test parameter. In our case, the test parameter type is 
```fortran
type, extends(AbstractTestParameter) :: pencilSize
    integer :: nx, ny, nz
 contains
    procedure :: toString
end type pencilSize
```
and the test derived type
```f90
@testCase(testParameters={getParameters()}, constructor=newTestDeriv)
type, extends(ParameterizedTestCase) :: testDeriv
    type(pencilSize) :: pencil_size
contains
    procedure :: allocate_on_pencil
    procedure :: setup_coefficient_arrays
end type testDeriv
```
the `@testCase` is a directive indicating the pFUnit parser that the test type is parametrized on values returned by function `getParameters`, and tests should be instantiated using function `newTestDeriv`.

With this defined, we can write our test

```f90
@test
subroutine test_derx_odd_11(this)
    ! ...   
    class (testDeriv), intent(inout) :: this
    real, allocatable, dimension(:, :, :) :: func, dfunc, expected_dfunc
    real, allocatable :: ff(:), fs(:), fw(:)
    ! ...
    call derx_11(dfunc, func, di1, s, ff, fs, fw, &
         & this % pencil_size % nx, &
         & this % pencil_size % ny, &
         & this % pencil_size % nz, &
         npaire = 0)

    @assertEqual(dfunc, expected_dfunc, tolerance=1E-2)

    deallocate(func, dfunc, expected_dfunc)

  end subroutine test_derx_odd_11
```

